### PR TITLE
Fix twitter bot import path

### DIFF
--- a/src/twitter_bot/reply_mentions.py
+++ b/src/twitter_bot/reply_mentions.py
@@ -1,8 +1,14 @@
 
 import os
+import sys
 import tweepy
 import openai
 import time
+
+# Allow running this script directly via `python src/twitter_bot/reply_mentions.py`
+# by adding the repository root to `sys.path` so that `src` can be imported.
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from src.utils import is_spam, generate_context_reply
 
 openai.api_key = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
## Summary
- ensure `reply_mentions.py` can import project modules when run directly

## Testing
- `python src/twitter_bot/reply_mentions.py` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_684823f633e48326bb64daac0831a668