### PR TITLE
Fix reply bot import path

### DIFF
--- a/src/twitter_bot/reply_mentions.py
+++ b/src/twitter_bot/reply_mentions.py
@@ -7,7 +7,9 @@ import time
 
 # Allow running this script directly via `python src/twitter_bot/reply_mentions.py`
 # by adding the repository root to `sys.path` so that `src` can be imported.
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add the repository root to ``sys.path`` so imports work when executed directly
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.append(ROOT_DIR)
 
 from src.utils import is_spam, generate_context_reply
 


### PR DESCRIPTION
## Summary
- fix import path in `reply_mentions.py` so GitHub Actions can run it directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485f8112648326ae37014aff535002