### PR TITLE
Add Twitter auth test workflow

### DIFF
--- a/.github/workflows/test_auth.yml
+++ b/.github/workflows/test_auth.yml
@@ -1,0 +1,23 @@
+name: Twitter Auth Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  auth-test:
+    runs-on: ubuntu-latest
+    env:
+      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+      TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+      TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+      TWITTER_ACCESS_SECRET: ${{ secrets.TWITTER_ACCESS_SECRET }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Test Twitter Authorization
+        run: python tests/test_auth.py

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ The automation is designed to run on free tiers such as GitHub Actions.
 2. Set the following environment variables for the APIs you intend to use:
    - `OPENAI_API_KEY`
    - `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_SECRET`
- - `META_ACCESS_TOKEN`, `IG_BUSINESS_ID` (optional for Instagram)
-3. Edit `topics.txt` with lines of text describing the content you want posted.
+   - `META_ACCESS_TOKEN`, `IG_BUSINESS_ID` (optional for Instagram)
+3. Run the auth test script to verify your Twitter credentials:
+   ```bash
+   python tests/test_auth.py
+   ```
+4. Edit `topics.txt` with lines of text describing the content you want posted.
    Add seed images to the `images/` directory to influence the generated art.
-4. Run the individual scripts from the `src` directory.  For example:
+5. Run the individual scripts from the `src` directory.  For example:
    ```bash
    python src/twitter_bot/reply_mentions.py
    ```

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,28 @@
+import os
+import tweepy
+
+
+def main():
+    print("🔐 Testing Twitter API credentials...")
+
+    auth = tweepy.OAuth1UserHandler(
+        os.getenv("TWITTER_API_KEY"),
+        os.getenv("TWITTER_API_SECRET"),
+        os.getenv("TWITTER_ACCESS_TOKEN"),
+        os.getenv("TWITTER_ACCESS_SECRET")
+    )
+
+    api = tweepy.API(auth)
+
+    try:
+        user = api.verify_credentials()
+        if user:
+            print(f"✅ Auth successful. Logged in as: @{user.screen_name}")
+        else:
+            print("❌ Auth failed. No user returned.")
+    except Exception as e:
+        print("❌ Auth exception:", e)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include a simple `tests/test_auth.py` script
- document how to run the auth test in README
- add `test_auth.yml` workflow for manual credential validation

## Testing
- `python -m py_compile tests/test_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6848c961971c8326af60cebee26d8bca