### PR TITLE
Update scheduler to run once and adjust workflow timing

### DIFF
--- a/.github/workflows/social_media.yml
+++ b/.github/workflows/social_media.yml
@@ -2,7 +2,8 @@ name: Social Media Automation
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    # Run every 8 hours (3 times a day)
+    - cron: '0 */8 * * *'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains a lightweight collection of scripts that automate basic
 * **Context‑Aware Auto‑Replies** – comment and DM responses include FAQ links and ignore spam keywords.
 * **Follow/Unfollow & Engagement Bot** – automatically follow engagers, like follower posts, and unfollow nonfollowers after a set period.
 * **Meme + Video Generator** – turns trending AI meme formats into short captioned videos.
-* **Multi‑Platform Scheduler** – generates AI posts and schedules them three times per day for Twitter, Facebook, Instagram, and TikTok.
+* **Multi‑Platform Scheduler** – generates AI posts for Twitter, Facebook, Instagram, and TikTok when triggered.
 * **Topic & Image Sources** – place text prompts in `topics.txt` and seed images in the `images/` folder. One topic and image are selected at random for each post.
 
 The automation is designed to run on free tiers such as GitHub Actions.
@@ -36,7 +36,7 @@ The automation is designed to run on free tiers such as GitHub Actions.
    python src/twitter_bot/reply_mentions.py
    ```
 
-GitHub Actions workflows in `.github/workflows/` run the bots on a schedule. `social_media.yml` posts content daily and handles replies.
+GitHub Actions workflows in `.github/workflows/` run the bots on a schedule. `social_media.yml` runs every eight hours and posts content to each platform.
 
 ## Repository Layout
 
@@ -46,7 +46,7 @@ src/
   video_bot/generate_video.py     # AI‑generated vertical video
   instagram_bot/instagram_replies.py  # Meta API scaffold
   facebook_bot/reply_comments.py   # Facebook comment replies
-  post_scheduler.py               # Randomized multi-platform posting
+  post_scheduler.py               # Immediate multi-platform posting
   engagement_bot.py               # Follow/unfollow automation
   meme_generator.py               # Trending meme video creator
 ```

--- a/src/post_scheduler.py
+++ b/src/post_scheduler.py
@@ -8,7 +8,6 @@ from email.mime.text import MIMEText
 import openai
 import requests
 import tweepy
-from apscheduler.schedulers.blocking import BlockingScheduler
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 TOPIC_FILE = os.getenv("TOPIC_FILE", "topics.txt")
@@ -300,20 +299,12 @@ def post_content(platform: str):
         print(f"Failed to post on {platform}:", exc)
 
 
-def schedule_daily_posts():
-    scheduler = BlockingScheduler()
+def post_to_all_platforms() -> None:
+    """Immediately post content to all available platforms."""
     platforms = ["twitter", "facebook", "instagram", "tiktok"]
     for platform in platforms:
-        for run_time in generate_random_times():
-            scheduler.add_job(post_content, "date", run_date=run_time, args=[platform])
-            print(f"Scheduled {platform} post for {run_time}")
-    try:
-        scheduler.start()
-    except Exception:
-        err = traceback.format_exc()
-        send_error_email("Scheduler failed", err)
-        print("Scheduler failed:", err)
+        post_content(platform)
 
 
 if __name__ == "__main__":
-    schedule_daily_posts()
+    post_to_all_platforms()


### PR DESCRIPTION
## Summary
- run post_scheduler once per invocation instead of using APScheduler
- trigger social_media workflow every eight hours
- update docs to reflect new behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_68497a659ad88326b35e41553ce54451