### PR TITLE
Add PYTHONPATH step to workflow

### DIFF
--- a/.github/workflows/social_media.yml
+++ b/.github/workflows/social_media.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Schedule AI Posts


### PR DESCRIPTION
## Summary
- set PYTHONPATH env var in the social media workflow so scripts can use the repo root

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_684996512ec0832682232242a86bde1b