### PR TITLE
Add text-only daily tweet bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains a lightweight collection of scripts that automate basic
 * **Multi‑Platform Scheduler** – generates AI posts for Twitter, Facebook, Instagram, and TikTok when triggered.
 * **Topic & Image Sources** – place text prompts in `topics.txt` and seed images in the `images/` folder. One topic and image are selected at random for each post.
 * **Daily Twitter Bot** – once a day generates a tweet with hashtags and an AI image using a random topic and seed picture.
+* **Text‑Only Tweet Bot** – variant that posts a short tweet with relevant hashtags but no image.
 
 The automation is designed to run on free tiers such as GitHub Actions.
 
@@ -51,6 +52,7 @@ src/
   engagement_bot.py               # Follow/unfollow automation
   meme_generator.py               # Trending meme video creator
   twitter_bot/daily_tweet.py      # Posts one AI-generated tweet per day
+  twitter_bot/daily_text_tweet.py # Text-only version of the daily tweet bot
 ```
 
 The repository retains the MIT license.

--- a/src/twitter_bot/daily_text_tweet.py
+++ b/src/twitter_bot/daily_text_tweet.py
@@ -1,0 +1,74 @@
+import os
+import random
+from datetime import datetime
+
+import tweepy
+from openai import OpenAI
+
+TOPIC_FILE = os.getenv("TOPIC_FILE", "topics.txt")
+STYLE_STATE_FILE = os.getenv("STYLE_STATE_FILE", "tweet_style.txt")
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+auth = tweepy.OAuth1UserHandler(
+    os.getenv("TWITTER_API_KEY"),
+    os.getenv("TWITTER_API_SECRET"),
+    os.getenv("TWITTER_ACCESS_TOKEN"),
+    os.getenv("TWITTER_ACCESS_SECRET"),
+)
+twitter_api = tweepy.API(auth)
+
+
+def _load_topics():
+    if not os.path.exists(TOPIC_FILE):
+        return ["our product"]
+    with open(TOPIC_FILE, "r") as f:
+        topics = [line.strip() for line in f if line.strip()]
+    return topics or ["our product"]
+
+
+def _get_random_topic():
+    return random.choice(_load_topics())
+
+
+def _next_style() -> str:
+    """Alternate between 'funny' and 'serious' styles."""
+    last = None
+    if os.path.exists(STYLE_STATE_FILE):
+        with open(STYLE_STATE_FILE, "r") as f:
+            last = f.read().strip()
+    style = "serious" if last == "funny" else "funny"
+    with open(STYLE_STATE_FILE, "w") as f:
+        f.write(style)
+    return style
+
+
+def generate_tweet(topic: str, style: str) -> str:
+    prompt = (
+        f"Write a short {style} tweet about {topic}. "
+        "Add a couple popular hashtags relevant to the topic."
+    )
+    res = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return res.choices[0].message.content.strip()
+
+
+def post_tweet(text: str):
+    try:
+        twitter_api.update_status(status=text)
+    except tweepy.errors.TweepyException as exc:
+        print(f"Failed to post tweet: {exc}")
+
+
+def main():
+    style = _next_style()
+    topic = _get_random_topic()
+    tweet = generate_tweet(topic, style)
+    post_tweet(tweet)
+    print(f"[{datetime.now().isoformat()}] Tweeted with style {style} about '{topic}'")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a new script `daily_text_tweet.py` that posts a short tweet with ChatGPT generated text and hashtags
- document this new bot in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai)*
- `python tests/test_auth.py` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_684a301b800c832684666c8637d903e4